### PR TITLE
Fix likelihoodField-bug index calculation and data types

### DIFF
--- a/ike_localization/include/ike_localization/mcl/likelihoodField.hpp
+++ b/ike_localization/include/ike_localization/mcl/likelihoodField.hpp
@@ -31,7 +31,7 @@ public:
   double resolution_;         // 受け取ったマップの解像度
   double origin_x_;           // 受け取ったマップの原点x
   double origin_y_;           // 受け取ったマップの原点y
-  std::vector<int8_t> data_;  // 受け取ったマップの各画素の情報
+  std::vector<double> data_;  // 受け取ったマップの各画素の情報
 };
 }  // namespace mcl
 

--- a/ike_localization/src/mcl/likelihoodField.cpp
+++ b/ike_localization/src/mcl/likelihoodField.cpp
@@ -30,8 +30,8 @@ LikelihoodField::~LikelihoodField(){};
 
 void LikelihoodField::createLikelihoodField()
 {
-  for (uint32_t y = 0; y < width_ / 2; y++)
-    for (uint32_t x = 0; x < height_ / 2; x++)
+  for (uint32_t y = 0; y < width_; y++)
+    for (uint32_t x = 0; x < height_; x++)
       if (data_[width_ * (height_ - y - 1) + x] == 100) {
         calculateLikelihood(x, y);
       }

--- a/ike_localization/src/mcl/likelihoodField.cpp
+++ b/ike_localization/src/mcl/likelihoodField.cpp
@@ -16,7 +16,7 @@ LikelihoodField::LikelihoodField(
   resolution_(resolution),
   origin_x_(origin_x),
   origin_y_(origin_y),
-  data_(data)
+  data_(data.begin(), data.end())
 {
   std::cout << "Create LikelihoodField."
             << "\n";
@@ -30,11 +30,17 @@ LikelihoodField::~LikelihoodField(){};
 
 void LikelihoodField::createLikelihoodField()
 {
-  for (uint32_t y = 0; y < width_; y++)
-    for (uint32_t x = 0; x < height_; x++)
+  for (uint32_t y = 0; y < width_ / 2; y++)
+    for (uint32_t x = 0; x < height_ / 2; x++)
       if (data_[width_ * (height_ - y - 1) + x] == 100) {
         calculateLikelihood(x, y);
       }
+
+  for (auto & data : data_) {
+    data /= 100;
+    if (data < 1.0e-10) data = 1.0e-10;
+    if (data == 0) data = 1.0e-10;
+  }
 }
 
 void LikelihoodField::calculateLikelihood(uint32_t map_x, uint32_t map_y)
@@ -68,6 +74,19 @@ double LikelihoodField::calculateProb(double stochastic_variable, double likelih
 
 double LikelihoodField::normalizePdf(double max_pdf, double pdf) { return (pdf / max_pdf) * 100; }
 
-void LikelihoodField::getLikelihoodField(std::vector<int8_t> & data) { data = data_; }
+void LikelihoodField::getLikelihoodField(std::vector<int8_t> & data)
+{
+  // to do fix
+
+  auto copy_data = data_;
+
+  for (auto & data : copy_data) {
+    data = data * 100;
+  }
+
+  std::vector<int8_t> int_data(copy_data.begin(), copy_data.end());
+
+  data = int_data;
+}
 
 }  // namespace mcl


### PR DESCRIPTION
* 尤度場のデータ型をdoubleに変更
* 尤度場のデータのインデックス計算を修正
* 尤度場のデータが0だとエラーになるので、0を1.0e-10に変換