### PR TITLE
Remove Dockerfile colcon_build cache

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -35,7 +35,8 @@ RUN cd /home/$USERNAME/ike_nav_ws/ && \
     colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release && \
     : "remove cache" && \
     sudo apt-get autoremove -y -qq && \
-    sudo rm -rf /var/lib/apt/lists/*
+    sudo rm -rf /var/lib/apt/lists/* && \
+    rm -rf build log
 
 RUN mkdir -p $HOME/.gazebo/models && \
     wget -O /tmp/sun http://models.gazebosim.org/sun/model.tar.gz && \


### PR DESCRIPTION
* ビルドの生成物はinstall以外は、不要であるため削除