### PR TITLE
Fix to initialize x and y in mean_pose

### DIFF
--- a/ike_localization/src/mcl/mcl.cpp
+++ b/ike_localization/src/mcl/mcl.cpp
@@ -63,6 +63,8 @@ void Mcl::getMeanParticle(Particle & particle)
   Particle mean_pose;
   double euler_sin = 0.;
   double euler_cos = 0.;
+  mean_pose.pose.position.x = mean_pose.pose.position.y = 0;
+
   for (auto p : particles_) {
     mean_pose.pose.position.x += p.pose.position.x;
     mean_pose.pose.position.y += p.pose.position.y;


### PR DESCRIPTION
* demoのコードが動かなかったので修正した
  * 原因は、変数の末初期化によるNANエラー（tfがエラーを吐いていた）